### PR TITLE
Introduce Client interface that CRUD API's can implement

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -59,14 +59,6 @@
   version = "v1.1.0"
 
 [[projects]]
-  digest = "1:0bfbe13936953a98ae3cfe8ed6670d396ad81edf069a806d2f6515d7bb6950df"
-  name = "github.com/google/btree"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
-  version = "v1.0.0"
-
-[[projects]]
   digest = "1:41bfd4219241b7f7d6e6fdb13fc712576f1337e68e6b895136283b76928fdd66"
   name = "github.com/google/gofuzz"
   packages = ["."]
@@ -84,17 +76,6 @@
   pruneopts = "UT"
   revision = "e73c7ec21d36ddb0711cb36d1502d18363b5c2c9"
   version = "v0.3.0"
-
-[[projects]]
-  branch = "master"
-  digest = "1:5fc0e23b254a1bd7d8d2d42fa093ba33471d08f52fe04afd3713adabb5888dc3"
-  name = "github.com/gregjones/httpcache"
-  packages = [
-    ".",
-    "diskcache",
-  ]
-  pruneopts = "UT"
-  revision = "901d90724c7919163f472a9812253fb26761123d"
 
 [[projects]]
   digest = "1:eaefc85d32c03e5f0c2b88ea2f79fce3d993e2c78316d21319575dd4ea9153ca"
@@ -119,30 +100,6 @@
   pruneopts = "UT"
   revision = "94122c33edd36123c84d5368cfb2b69df93a0ec8"
   version = "v1.0.1"
-
-[[projects]]
-  digest = "1:4af5ef5028af0c996043a4ed5731c51a649fc3d27d700a2d88a47d51591ab993"
-  name = "github.com/operator-framework/operator-sdk"
-  packages = ["pkg/restmapper"]
-  pruneopts = "UT"
-  revision = "78c472461e75e6c64589cfadf577a2004b8a26b3"
-  version = "v0.8.0"
-
-[[projects]]
-  branch = "master"
-  digest = "1:89da0f0574bc94cfd0ac8b59af67bf76cdd110d503df2721006b9f0492394333"
-  name = "github.com/petar/GoLLRB"
-  packages = ["llrb"]
-  pruneopts = "UT"
-  revision = "33fb24c13b99c46c93183c291836c573ac382536"
-
-[[projects]]
-  digest = "1:a8c2725121694dfbf6d552fb86fe6b46e3e7135ea05db580c28695b916162aad"
-  name = "github.com/peterbourgon/diskv"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "0be1b92a6df0e4f5cb0a5d15fb7f643d0ad93ce6"
-  version = "v3.0.0"
 
 [[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
@@ -184,18 +141,10 @@
   version = "v1.9.1"
 
 [[projects]]
-  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
-  name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
-  pruneopts = "UT"
-  revision = "de0752318171da717af4ce24d0a2e8626afaeb11"
-
-[[projects]]
   branch = "master"
-  digest = "1:b8c5023d876c0e40eca8729fb4516dcb62887e11524de5a38de8a2067b69a4ec"
+  digest = "1:01831e6da6dfda2ea208bc4a153f6fb2fe02b0baec3af50f3b61c0d87d99a3f7"
   name = "golang.org/x/net"
   packages = [
-    "context",
     "http/httpguts",
     "http2",
     "http2/hpack",
@@ -203,27 +152,6 @@
   ]
   pruneopts = "UT"
   revision = "4829fb13d2c62012c17688fa7f629f371014946d"
-
-[[projects]]
-  digest = "1:9359217acc6040b4be710ce34473acef28023ad39bfafecea34ffaea7f1e1890"
-  name = "golang.org/x/oauth2"
-  packages = [
-    ".",
-    "internal",
-  ]
-  pruneopts = "UT"
-  revision = "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
-
-[[projects]]
-  branch = "master"
-  digest = "1:656ce95b4cdf841c00825f4cb94f6e0e1422d7d6faaf3094e94cd18884a32251"
-  name = "golang.org/x/sys"
-  packages = [
-    "unix",
-    "windows",
-  ]
-  pruneopts = "UT"
-  revision = "a129542de9ae0895210abff9c95d67a1f33cb93d"
 
 [[projects]]
   digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
@@ -249,29 +177,6 @@
   pruneopts = "UT"
   revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
   version = "v0.3.2"
-
-[[projects]]
-  digest = "1:d37b0ef2944431fe9e8ef35c6fffc8990d9e2ca300588df94a6890f3649ae365"
-  name = "golang.org/x/time"
-  packages = ["rate"]
-  pruneopts = "UT"
-  revision = "f51c12702a4d776e4c1fa9b0fabab841babae631"
-
-[[projects]]
-  digest = "1:6eb6e3b6d9fffb62958cf7f7d88dbbe1dd6839436b0802e194c590667a40412a"
-  name = "google.golang.org/appengine"
-  packages = [
-    "internal",
-    "internal/base",
-    "internal/datastore",
-    "internal/log",
-    "internal/remote_api",
-    "internal/urlfetch",
-    "urlfetch",
-  ]
-  pruneopts = "UT"
-  revision = "54a98f90d1c46b7731eb8fb305d2a321c30ef610"
-  version = "v1.5.0"
 
 [[projects]]
   digest = "1:ef72505cf098abdd34efeea032103377bec06abb61d8a06f002d5d296a4b1185"
@@ -331,15 +236,13 @@
   revision = "781da4e7b28a3d23a108ec63be899e68fa745011"
 
 [[projects]]
-  digest = "1:9fc61121eb55579a20a4516420415b2e76cb2af39620a32abc5c426e191586d5"
+  digest = "1:3ff6c70b1141708359606adc3c9750610db552a0dfc2075612ae04081041677f"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
-    "pkg/api/meta",
     "pkg/api/resource",
     "pkg/apis/meta/v1",
     "pkg/apis/meta/v1/unstructured",
-    "pkg/apis/meta/v1beta1",
     "pkg/conversion",
     "pkg/conversion/queryparams",
     "pkg/fields",
@@ -350,11 +253,9 @@
     "pkg/runtime/serializer/json",
     "pkg/runtime/serializer/protobuf",
     "pkg/runtime/serializer/recognizer",
-    "pkg/runtime/serializer/streaming",
     "pkg/runtime/serializer/versioning",
     "pkg/selection",
     "pkg/types",
-    "pkg/util/clock",
     "pkg/util/errors",
     "pkg/util/framer",
     "pkg/util/intstr",
@@ -369,38 +270,18 @@
     "pkg/util/validation",
     "pkg/util/validation/field",
     "pkg/util/yaml",
-    "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/json",
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "UT"
-  revision = "2b1284ed4c93a43499e781493253e2ac5959c4fd"
-  version = "kubernetes-1.13.1"
+  revision = "f2f3a405f61d6c2cdc0d00687c1b5d90de91e9f0"
+  version = "kubernetes-1.15.4"
 
 [[projects]]
-  digest = "1:439f7c74c7fbf4744cbda7690d90a5975c039fdaa47ba7349b0951966ece5200"
+  digest = "1:b1bacdc9d7b76817e4652d5c91fc919f83ae9fd86e57885bc1dc79ec3b1c9a8f"
   name = "k8s.io/client-go"
-  packages = [
-    "discovery",
-    "dynamic",
-    "kubernetes/scheme",
-    "pkg/apis/clientauthentication",
-    "pkg/apis/clientauthentication/v1alpha1",
-    "pkg/apis/clientauthentication/v1beta1",
-    "pkg/version",
-    "plugin/pkg/client/auth/exec",
-    "rest",
-    "rest/watch",
-    "restmapper",
-    "tools/clientcmd/api",
-    "tools/metrics",
-    "transport",
-    "util/cert",
-    "util/connrotation",
-    "util/flowcontrol",
-    "util/integer",
-  ]
+  packages = ["kubernetes/scheme"]
   pruneopts = "UT"
   revision = "8d9ed539ba3134352c586810e749e58df4e94e4f"
   version = "kubernetes-1.13.1"
@@ -435,11 +316,9 @@
     "github.com/evanphx/json-patch",
     "github.com/go-logr/logr",
     "github.com/go-logr/zapr",
-    "github.com/operator-framework/operator-sdk/pkg/restmapper",
     "go.uber.org/zap",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/errors",
-    "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
     "k8s.io/apimachinery/pkg/runtime",
@@ -447,9 +326,7 @@
     "k8s.io/apimachinery/pkg/util/jsonmergepatch",
     "k8s.io/apimachinery/pkg/util/strategicpatch",
     "k8s.io/apimachinery/pkg/util/yaml",
-    "k8s.io/client-go/dynamic",
     "k8s.io/client-go/kubernetes/scheme",
-    "k8s.io/client-go/rest",
     "sigs.k8s.io/yaml",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,11 +27,7 @@
 
 [[constraint]]
   name = "k8s.io/apimachinery"
-  version = "kubernetes-1.13.1"
-
-[[constraint]]
-  name = "github.com/operator-framework/operator-sdk"
-  version = "=v0.8.0"
+  version = "kubernetes-1.15.4"
 
 [prune]
   go-tests = true

--- a/client.go
+++ b/client.go
@@ -1,0 +1,93 @@
+package manifestival
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type Client interface {
+	Create(obj *unstructured.Unstructured, options *metav1.CreateOptions) error
+	Update(obj *unstructured.Unstructured, options *metav1.UpdateOptions) error
+	Delete(obj *unstructured.Unstructured, options *metav1.DeleteOptions) error
+	Get(obj *unstructured.Unstructured, options *metav1.GetOptions) (*unstructured.Unstructured, error)
+}
+
+// Functional options pattern
+type ClientOption func(*ClientOptions)
+
+type ClientOptions struct {
+	DryRun             []string
+	FieldManager       string
+	GracePeriodSeconds *int64
+	Preconditions      *metav1.Preconditions
+	PropagationPolicy  *metav1.DeletionPropagation
+	ResourceVersion    string
+}
+
+func NewOptions(opts ...ClientOption) *ClientOptions {
+	result := &ClientOptions{}
+	for _, opt := range opts {
+		opt(result)
+	}
+	return result
+}
+
+func (o *ClientOptions) ForCreate() *metav1.CreateOptions {
+	return &metav1.CreateOptions{
+		DryRun:       o.DryRun,
+		FieldManager: o.FieldManager,
+	}
+}
+
+func (o *ClientOptions) ForUpdate() *metav1.UpdateOptions {
+	return &metav1.UpdateOptions{
+		DryRun:       o.DryRun,
+		FieldManager: o.FieldManager,
+	}
+}
+
+func (o *ClientOptions) ForDelete() *metav1.DeleteOptions {
+	return &metav1.DeleteOptions{
+		DryRun:             o.DryRun,
+		GracePeriodSeconds: o.GracePeriodSeconds,
+		Preconditions:      o.Preconditions,
+		PropagationPolicy:  o.PropagationPolicy,
+	}
+}
+
+func (o *ClientOptions) ForGet() *metav1.GetOptions {
+	return &metav1.GetOptions{
+		ResourceVersion: o.ResourceVersion,
+	}
+}
+
+func DryRun(v []string) ClientOption {
+	return func(o *ClientOptions) {
+		o.DryRun = v
+	}
+}
+func FieldManager(v string) ClientOption {
+	return func(o *ClientOptions) {
+		o.FieldManager = v
+	}
+}
+func GracePeriodSeconds(v *int64) ClientOption {
+	return func(o *ClientOptions) {
+		o.GracePeriodSeconds = v
+	}
+}
+func Preconditions(v *metav1.Preconditions) ClientOption {
+	return func(o *ClientOptions) {
+		o.Preconditions = v
+	}
+}
+func PropagationPolicy(v *metav1.DeletionPropagation) ClientOption {
+	return func(o *ClientOptions) {
+		o.PropagationPolicy = v
+	}
+}
+func ResourceVersion(v string) ClientOption {
+	return func(o *ClientOptions) {
+		o.ResourceVersion = v
+	}
+}

--- a/transform.go
+++ b/transform.go
@@ -35,7 +35,7 @@ func (f *Manifest) Transform(fns ...Transformer) (*Manifest, error) {
 		}
 		results = append(results, *spec)
 	}
-	return &Manifest{Resources: results, client: f.client, mapper: f.mapper}, nil
+	return &Manifest{Resources: results, client: f.client}, nil
 }
 
 // InjectNamespace creates a Transformer which adds a namespace to existing

--- a/transform_test.go
+++ b/transform_test.go
@@ -6,11 +6,10 @@ import (
 
 	. "github.com/manifestival/manifestival"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/client-go/rest"
 )
 
 func TestTransform(t *testing.T) {
-	m, _ := NewManifest("testdata/tree", true, &rest.Config{})
+	m, _ := NewManifest("testdata/tree", true, nil)
 	f := &m
 	actual := f.Resources
 	if len(actual) != 5 {
@@ -38,7 +37,7 @@ func TestTransform(t *testing.T) {
 }
 
 func TestTransformCombo(t *testing.T) {
-	m, err := NewManifest("testdata/tree", true, &rest.Config{})
+	m, err := NewManifest("testdata/tree", true, nil)
 	f := &m
 	if len(f.Resources) != 5 {
 		t.Errorf("Failed to read all resources: %s", f.Resources)
@@ -76,7 +75,7 @@ func TestInjectNamespace(t *testing.T) {
 			t.Errorf("Expected '%s', got '%s'", expected, ns)
 		}
 	}
-	m, err := NewManifest("testdata/crb.yaml", true, &rest.Config{})
+	m, err := NewManifest("testdata/crb.yaml", true, nil)
 	f := &m
 	if len(f.Resources) != 2 {
 		t.Errorf("Expected 2 resources from crb.yaml, got %d (%s)", len(f.Resources), err)
@@ -109,7 +108,7 @@ func TestInjectNamespaceRoleBinding(t *testing.T) {
 			t.Errorf("Expected '%s', got '%s'", expected, ns)
 		}
 	}
-	m, err := NewManifest("testdata/rb.yaml", true, &rest.Config{})
+	m, err := NewManifest("testdata/rb.yaml", true, nil)
 	f := &m
 	if len(f.Resources) != 2 {
 		t.Errorf("Expected 2 resources from crb.yaml, got %d (%s)", len(f.Resources), err)
@@ -146,7 +145,7 @@ func TestInjectNamespaceWebhook(t *testing.T) {
 		}
 	}
 
-	m, err := NewManifest("testdata/hooks.yaml", true, &rest.Config{})
+	m, err := NewManifest("testdata/hooks.yaml", true, nil)
 	f := &m
 	if len(f.Resources) != 1 {
 		t.Errorf("Expected 1 resource, got %d", len(f.Resources))
@@ -176,7 +175,7 @@ func TestInjectNamespaceAPIService(t *testing.T) {
 		}
 	}
 
-	m, err := NewManifest("testdata/apiservice.yaml", true, &rest.Config{})
+	m, err := NewManifest("testdata/apiservice.yaml", true, nil)
 	f := &m
 	if len(f.Resources) != 1 {
 		t.Errorf("Expected 1 resource, got %d", len(f.Resources))


### PR DESCRIPTION
This fixes #4 sans the implementations, and also enables a crude alternative to #3 since one could enable the k8s `DryRun` mode for `ApplyAll` and theoretically see the results of what would be applied in the log.