### PR TITLE
Introduce Source interface from which Manifests can be created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Introduced the `Source` interface, enabling the creation of a
+  Manifest from any source [#11](https://github.com/manifestival/manifestival/pull/11)
+- Added a `ManifestFrom` constructor to complement `NewManifest`,
+  which now only works for files, directories, and URL's
+- Use `ManifestFrom(Recursive("dirname/"))` to create a manifest from
+  a recursive directory search for yaml files.
+- Use `ManifestFrom(Slice(v))` to create a manifest from any `v` of type
+  `[]unstructured.Unstructured`
+- Use `ManifestFrom(Reader(r))` to create a manifest from any `r` of
+  type `io.Reader`
+
 ### Changed
 
-- Split `ClientOption` into `ApplyOption` and `DeleteOption` adding
-  `IgnoreNotFound` to the latter, ensuring that impls honor it,
-  simplifying delete logic for users calling the `Client` directly.
-  All `ApplyOptions` apply to both creates and updates [#12](https://github.com/manifestival/manifestival/pull/12)
+- Manifests created from a recursive directory search are now only
+  possible via the new `ManifestFrom` constructor. The `NewManifest`
+  constructor no longer supports a `recursive` option.
+- Moved the path/yaml parsing logic into its own `sources` to reduce
+  the exported names in the `manifestival` package.
+- Replaced the `ClientOption` type with `ApplyOption` and
+  `DeleteOption`, adding `IgnoreNotFound` to the latter, thereby
+  enabling `Client` implementations to honor it, simplifying delete
+  logic for users invoking the `Client` directly. All `ApplyOptions`
+  apply to both creates and updates
+  [#12](https://github.com/manifestival/manifestival/pull/12)
+
 
 ## [0.1.0] - 2019-02-17
 
@@ -33,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Other small fixes from the old `client-go` branch have also been
   merged 
 
+
 ## [0.0.0] - 2019-01-11
 
 ### Changed
@@ -42,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - There were no releases in the old repo, just two branches: `master`,
   based on the `controller-runtime` client API, and `client-go`, based
   on the `client-go` API. 
+
 
 [controller-runtime]: https://github.com/manifestival/controller-runtime-client
 [client-go]: https://github.com/manifestival/client-go-client

--- a/options.go
+++ b/options.go
@@ -2,32 +2,16 @@ package manifestival
 
 import "github.com/go-logr/logr"
 
-type options struct {
-	recursive bool
-	logger    logr.Logger
-	client    Client
-}
-
-type Option func(*options)
-
-func Recursive(opts *options) {
-	opts.recursive = true
-}
-
-func UseRecursive(v bool) Option {
-	return func(opts *options) {
-		opts.recursive = v
-	}
-}
+type Option func(*Manifest)
 
 func UseLogger(log logr.Logger) Option {
-	return func(o *options) {
-		o.logger = log
+	return func(m *Manifest) {
+		m.log = log
 	}
 }
 
 func UseClient(client Client) Option {
-	return func(o *options) {
-		o.client = client
+	return func(m *Manifest) {
+		m.client = client
 	}
 }

--- a/source.go
+++ b/source.go
@@ -1,0 +1,46 @@
+package manifestival
+
+import (
+	"io"
+
+	"github.com/manifestival/manifestival/sources"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type Source interface {
+	Parse() ([]unstructured.Unstructured, error)
+}
+
+// Implementations
+var _ Source = Path("")
+var _ Source = Recursive("")
+var _ Source = Slice([]unstructured.Unstructured{})
+var _ Source = reader{} // see Reader(io.Reader)
+
+type Path string
+type Recursive string
+type Slice []unstructured.Unstructured
+
+func Reader(r io.Reader) Source {
+	return reader{r}
+}
+
+func (p Path) Parse() ([]unstructured.Unstructured, error) {
+	return sources.Parse(string(p), false)
+}
+
+func (r Recursive) Parse() ([]unstructured.Unstructured, error) {
+	return sources.Parse(string(r), true)
+}
+
+func (s Slice) Parse() ([]unstructured.Unstructured, error) {
+	return []unstructured.Unstructured(s), nil
+}
+
+func (r reader) Parse() ([]unstructured.Unstructured, error) {
+	return sources.Decode(r.real)
+}
+
+type reader struct {
+	real io.Reader
+}

--- a/source_test.go
+++ b/source_test.go
@@ -1,0 +1,57 @@
+package manifestival_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+
+	. "github.com/manifestival/manifestival"
+)
+
+func TestFromReader(t *testing.T) {
+	tests := []struct {
+		name                string
+		reader              io.Reader
+		expectedApiVersions []string
+	}{{
+		name: "from_bytes",
+		reader: bytes.NewReader([]byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: v1
+kind: Service
+spec:
+  selector:
+    app: MyApp
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 9376
+`)),
+		expectedApiVersions: []string{"apps/v1", "v1"},
+	}}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%s", tc.name), func(t *testing.T) {
+			m, err := ManifestFrom(Reader(tc.reader))
+			if err != nil {
+				t.Fatalf("FromReader returned: %v", err)
+			}
+
+			foundApiVersions := make([]string, 0)
+			for _, r := range m.Resources {
+				foundApiVersions = append(foundApiVersions, r.GetAPIVersion())
+			}
+			if !reflect.DeepEqual(tc.expectedApiVersions, foundApiVersions) {
+				t.Fatalf("Expected API kinds %v but found %v", tc.expectedApiVersions, foundApiVersions)
+			}
+		})
+	}
+}

--- a/sources/path.go
+++ b/sources/path.go
@@ -1,7 +1,6 @@
-package manifestival
+package sources
 
 import (
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -10,7 +9,6 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 // Parse parses YAML files into Unstructured objects.
@@ -65,7 +63,7 @@ func readFile(pathname string) ([]unstructured.Unstructured, error) {
 	}
 	defer file.Close()
 
-	return decode(file)
+	return Decode(file)
 }
 
 // readDir parses all files in a single directory and it's descendant directories
@@ -109,29 +107,7 @@ func readURL(url string) ([]unstructured.Unstructured, error) {
 	}
 	defer resp.Body.Close()
 
-	return decode(resp.Body)
-}
-
-// decode consumes the given reader and parses its contents as YAML.
-func decode(reader io.Reader) ([]unstructured.Unstructured, error) {
-	decoder := yaml.NewYAMLToJSONDecoder(reader)
-	objs := []unstructured.Unstructured{}
-	var err error
-	for {
-		out := unstructured.Unstructured{}
-		err = decoder.Decode(&out)
-		if err == io.EOF {
-			break
-		}
-		if err != nil || len(out.Object) == 0 {
-			continue
-		}
-		objs = append(objs, out)
-	}
-	if err != io.EOF {
-		return nil, err
-	}
-	return objs, nil
+	return Decode(resp.Body)
 }
 
 // isURL checks whether or not the given path parses as a URL.

--- a/sources/path_test.go
+++ b/sources/path_test.go
@@ -1,11 +1,11 @@
-package manifestival_test
+package sources_test
 
 import (
 	"os"
 	"path/filepath"
 	"testing"
 
-	. "github.com/manifestival/manifestival"
+	. "github.com/manifestival/manifestival/sources"
 )
 
 func TestParsing(t *testing.T) {
@@ -17,38 +17,38 @@ func TestParsing(t *testing.T) {
 		wantError bool
 	}{{
 		name: "single directory",
-		path: "testdata/tree",
+		path: "../testdata/tree",
 		want: []string{"a", "b"},
 	}, {
 		name:      "single directory, recursive",
-		path:      filepath.FromSlash("testdata/tree"),
+		path:      filepath.FromSlash("../testdata/tree"),
 		recursive: true,
 		want:      []string{"foo", "bar", "baz", "a", "b"},
 	}, {
 		name:      "single file",
-		path:      filepath.FromSlash("testdata/tree/dir/b.yaml"),
+		path:      filepath.FromSlash("../testdata/tree/dir/b.yaml"),
 		recursive: true,
 		want:      []string{"bar", "baz"},
 	}, {
 		name:      "single file, recursive",
-		path:      filepath.FromSlash("testdata/tree/file.yaml"),
+		path:      filepath.FromSlash("../testdata/tree/file.yaml"),
 		recursive: true,
 		want:      []string{"a", "b"},
 	}, {
 		name:      "missing file",
-		path:      filepath.FromSlash("testdata/missing"),
+		path:      filepath.FromSlash("../testdata/missing"),
 		wantError: true,
 	}, {
 		name:      "dangling symlink",
-		path:      filepath.FromSlash("testdata/dangling-symlink"),
+		path:      filepath.FromSlash("../testdata/dangling-symlink"),
 		wantError: true,
 	}, {
 		name:      "dangling symlink",
-		path:      filepath.FromSlash("testdata/dangling-symlink"),
+		path:      filepath.FromSlash("../testdata/dangling-symlink"),
 		wantError: true,
 	}, {
 		name:      "absolute path",
-		path:      filepath.Join(os.Getenv("PWD"), filepath.FromSlash("testdata/tree/dir/b.yaml")),
+		path:      filepath.Join(os.Getenv("PWD"), filepath.FromSlash("../testdata/tree/dir/b.yaml")),
 		recursive: true,
 		want:      []string{"bar", "baz"},
 	}, {
@@ -65,16 +65,16 @@ func TestParsing(t *testing.T) {
 		want: []string{"a", "b", "foo"},
 	}, {
 		name: "url and file",
-		path: "https://raw.githubusercontent.com/manifestival/manifestival/master/testdata/tree/file.yaml,testdata/tree/dir/a.yaml",
+		path: "https://raw.githubusercontent.com/manifestival/manifestival/master/testdata/tree/file.yaml,../testdata/tree/dir/a.yaml",
 		want: []string{"a", "b", "foo"},
 	}, {
 		name:      "url and directory, recursive",
-		path:      "https://raw.githubusercontent.com/manifestival/manifestival/master/testdata/tree/file.yaml,testdata/tree/dir",
+		path:      "https://raw.githubusercontent.com/manifestival/manifestival/master/testdata/tree/file.yaml,../testdata/tree/dir",
 		recursive: true,
 		want:      []string{"a", "b", "foo", "bar", "baz"},
 	}, {
 		name:      "file and directory, recursive",
-		path:      filepath.FromSlash("testdata/tree/file.yaml") + "," + filepath.FromSlash("testdata/tree/dir"),
+		path:      filepath.FromSlash("../testdata/tree/file.yaml") + "," + filepath.FromSlash("../testdata/tree/dir"),
 		recursive: true,
 		want:      []string{"a", "b", "foo", "bar", "baz"},
 	}, {

--- a/sources/yaml.go
+++ b/sources/yaml.go
@@ -1,0 +1,30 @@
+package sources
+
+import (
+	"io"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// decode consumes the given reader and parses its contents as YAML.
+func Decode(reader io.Reader) ([]unstructured.Unstructured, error) {
+	decoder := yaml.NewYAMLToJSONDecoder(reader)
+	objs := []unstructured.Unstructured{}
+	var err error
+	for {
+		out := unstructured.Unstructured{}
+		err = decoder.Decode(&out)
+		if err == io.EOF {
+			break
+		}
+		if err != nil || len(out.Object) == 0 {
+			continue
+		}
+		objs = append(objs, out)
+	}
+	if err != io.EOF {
+		return nil, err
+	}
+	return objs, nil
+}

--- a/transform_test.go
+++ b/transform_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTransform(t *testing.T) {
-	m, _ := NewManifest("testdata/tree", Recursive)
+	m, _ := ManifestFrom(Recursive("testdata/tree"))
 	f := &m
 	actual := f.Resources
 	if len(actual) != 5 {
@@ -37,7 +37,7 @@ func TestTransform(t *testing.T) {
 }
 
 func TestTransformCombo(t *testing.T) {
-	m, err := NewManifest("testdata/tree", UseRecursive(true))
+	m, err := ManifestFrom(Recursive("testdata/tree"))
 	f := &m
 	if len(f.Resources) != 5 {
 		t.Errorf("Failed to read all resources: %s", f.Resources)
@@ -75,7 +75,7 @@ func TestInjectNamespace(t *testing.T) {
 			t.Errorf("Expected '%s', got '%s'", expected, ns)
 		}
 	}
-	m, err := NewManifest("testdata/crb.yaml", UseRecursive(false))
+	m, err := NewManifest("testdata/crb.yaml")
 	f := &m
 	if len(f.Resources) != 2 {
 		t.Errorf("Expected 2 resources from crb.yaml, got %d (%s)", len(f.Resources), err)


### PR DESCRIPTION
Fixes #2

This removes `recursive` as an option when creating a Manifest because
that only applies to directories anyway.

Implementations for paths, recursive directories, `io.Reader`, and
`[]Unstructured`'s are supported, but anything that implements Source
should work, in theory.

I rearranged some of the files a bit just to avoid polluting the
Manifestival package.