### PR TITLE
Filter and Transform now return values, not pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - The `Manifest` struct's `Resources` member is no longer public.
   Instead, a `Manifest.Resources()` function is provided to return a
   deep copy of the manifest's resources, if needed.
+- `Transform` now returns a `Manifest` by value, like `Filter`. This
+  is a stronger indicator of immutability and conveniently matches the
+  return type of `NewManifest` [#18](https://github.com/manifestival/manifestival/issues/18)
 
 
 ## [0.1.0] - 2019-02-17

--- a/filter.go
+++ b/filter.go
@@ -12,7 +12,7 @@ type Predicate func(u *unstructured.Unstructured) bool
 // *all* Predicates return true. Any changes callers make to the
 // resources passed to their Predicate[s] will only be reflected in
 // the returned Manifest.
-func (f *Manifest) Filter(fns ...Predicate) *Manifest {
+func (f *Manifest) Filter(fns ...Predicate) Manifest {
 	result := *f
 	result.resources = []unstructured.Unstructured{}
 NEXT_RESOURCE:
@@ -26,7 +26,7 @@ NEXT_RESOURCE:
 		}
 		result.resources = append(result.resources, spec)
 	}
-	return &result
+	return result
 }
 
 // JustCRDs returns only CustomResourceDefinitions

--- a/manifestival.go
+++ b/manifestival.go
@@ -20,9 +20,9 @@ type Manifestival interface {
 	// Deletes all resources in the manifest
 	Delete(opts ...DeleteOption) error
 	// Transforms the resources within a Manifest
-	Transform(fns ...Transformer) (*Manifest, error)
+	Transform(fns ...Transformer) (Manifest, error)
 	// Filters resources in a Manifest; Predicates are AND'd
-	Filter(fns ...Predicate) *Manifest
+	Filter(fns ...Predicate) Manifest
 }
 
 // Manifest tracks a set of concrete resources which should be managed as a

--- a/transform.go
+++ b/transform.go
@@ -21,7 +21,7 @@ type Owner interface {
 // Transform applies an ordered set of Transformer functions to the
 // `Resources` in this Manifest.  If an error occurs, no resources are
 // transformed.
-func (f *Manifest) Transform(fns ...Transformer) (*Manifest, error) {
+func (f *Manifest) Transform(fns ...Transformer) (Manifest, error) {
 	result := *f
 	result.resources = f.Resources() // deep copies
 	for _, spec := range result.resources {
@@ -29,12 +29,12 @@ func (f *Manifest) Transform(fns ...Transformer) (*Manifest, error) {
 			if transform != nil {
 				err := transform(&spec)
 				if err != nil {
-					return nil, err
+					return Manifest{}, err
 				}
 			}
 		}
 	}
-	return &result, nil
+	return result, nil
 }
 
 // InjectNamespace creates a Transformer which adds a namespace to existing

--- a/transform_test.go
+++ b/transform_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func TestTransform(t *testing.T) {
-	m, _ := ManifestFrom(Recursive("testdata/tree"))
-	f := &m
+	f, _ := ManifestFrom(Recursive("testdata/tree"))
 	actual := f.Resources()
 	if len(actual) != 5 {
 		t.Errorf("Failed to read all resources: %s", actual)
@@ -37,8 +36,7 @@ func TestTransform(t *testing.T) {
 }
 
 func TestTransformCombo(t *testing.T) {
-	m, err := ManifestFrom(Recursive("testdata/tree"))
-	f := &m
+	f, err := ManifestFrom(Recursive("testdata/tree"))
 	if len(f.Resources()) != 5 {
 		t.Errorf("Failed to read all resources: %s", f.Resources())
 	}
@@ -75,8 +73,7 @@ func TestInjectNamespace(t *testing.T) {
 			t.Errorf("Expected '%s', got '%s'", expected, ns)
 		}
 	}
-	m, err := NewManifest("testdata/crb.yaml")
-	f := &m
+	f, err := NewManifest("testdata/crb.yaml")
 	if len(f.Resources()) != 2 {
 		t.Errorf("Expected 2 resources from crb.yaml, got %d (%s)", len(f.Resources()), err)
 	}
@@ -108,8 +105,7 @@ func TestInjectNamespaceRoleBinding(t *testing.T) {
 			t.Errorf("Expected '%s', got '%s'", expected, ns)
 		}
 	}
-	m, err := NewManifest("testdata/rb.yaml")
-	f := &m
+	f, err := NewManifest("testdata/rb.yaml")
 	if len(f.Resources()) != 2 {
 		t.Errorf("Expected 2 resources from crb.yaml, got %d (%s)", len(f.Resources()), err)
 	}
@@ -145,8 +141,7 @@ func TestInjectNamespaceWebhook(t *testing.T) {
 		}
 	}
 
-	m, err := NewManifest("testdata/hooks.yaml")
-	f := &m
+	f, err := NewManifest("testdata/hooks.yaml")
 	if len(f.Resources()) != 1 {
 		t.Errorf("Expected 1 resource, got %d", len(f.Resources()))
 	}
@@ -175,8 +170,7 @@ func TestInjectNamespaceAPIService(t *testing.T) {
 		}
 	}
 
-	m, err := NewManifest("testdata/apiservice.yaml")
-	f := &m
+	f, err := NewManifest("testdata/apiservice.yaml")
 	if len(f.Resources()) != 1 {
 		t.Errorf("Expected 1 resource, got %d", len(f.Resources()))
 	}


### PR DESCRIPTION
I should've changed this the first time I had to do the little "f=&m"
hack in the tests.

Fixes #18 