### PR TITLE
Add ByLabels to the filter library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - New `DryRun` function shows how applying the manifest will change
   the cluster. Its return value is a list of strategic merge patches
   [#29](https://github.com/manifestival/manifestival/pull/29)
+- New `ByLabels` function which is similar to ByLabel, but it accepts
+  multiple labels by map. It filter the resource that matches for any
+  of the labels.
+  [#32](https://github.com/manifestival/manifestival/pull/32)
 
 ### Changed
 

--- a/filter.go
+++ b/filter.go
@@ -86,6 +86,18 @@ func ByLabel(label, value string) Predicate {
 	}
 }
 
+// ByLabels returns true when the resource contains any of the labels.
+func ByLabels(labels map[string]string) Predicate {
+	return func(u *unstructured.Unstructured) bool {
+		for key, value := range labels {
+			if v := u.GetLabels()[key]; v == value {
+				return true
+			}
+		}
+		return false
+	}
+}
+
 // ByGVK returns resources of a particular GroupVersionKind
 func ByGVK(gvk schema.GroupVersionKind) Predicate {
 	return func(u *unstructured.Unstructured) bool {

--- a/filter_test.go
+++ b/filter_test.go
@@ -38,6 +38,14 @@ func TestFilter(t *testing.T) {
 		predicates: []Predicate{ByLabel("serving.knative.dev/release", "v0.12.1")},
 		count:      54,
 	}, {
+		name:       "Resources matche for the one label",
+		predicates: []Predicate{ByLabels(map[string]string{"networking.knative.dev/ingress-provider": "istio"})},
+		count:      5,
+	}, {
+		name:       "Resources matche for the one labels",
+		predicates: []Predicate{ByLabels(map[string]string{"networking.knative.dev/ingress-provider": "istio", "autoscaling.knative.dev/metric-provider": "custom-metrics"})},
+		count:      10,
+	}, {
 		name:       "First true then false",
 		predicates: []Predicate{True, False},
 		count:      0,


### PR DESCRIPTION
This patch adds `ByLabels()` to the filter library.

ByLabels() is similar to ByLabel(), but it accepts multiple labels by
map. It filters the resources which match for any of the labels.