### PR TITLE
When update fails, retry an overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 
-- Renamed `Replace` option to `Overwrite` to better match the behavior
-  of the `kubectl apply` subcommand. To use it: `m.Apply(Overwrite(true))`
+- Renamed the `Replace` option to `Overwrite` to better match the
+  behavior of the `kubectl apply` subcommand. Its default value is now
+  true, which will cause `Apply` to "automatically resolve conflicts
+  between the modified and live configuration by using values from the
+  modified configuration". To override this behavior and have invalid
+  patches return an error, call `Apply(Overwrite(false))` [#39](https://github.com/manifestival/manifestival/pull/39)
 - Made the `None` filter variadic, accepting multiple `Predicates`,
-  returning only those resources matching none of them.
+  returning only those resources matching none of them. [#36](https://github.com/manifestival/manifestival/issues/36)
   
 ### Added
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,31 @@
 
 
 [[projects]]
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = "UT"
+  revision = "37c8de3658fcb183f997c4e13e8337516ab753e6"
+  version = "v1.0.1"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   pruneopts = "UT"
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
+
+[[projects]]
+  digest = "1:4ddc17aeaa82cb18c5f0a25d7c253a10682f518f4b2558a82869506eec223d76"
+  name = "github.com/docker/distribution"
+  packages = [
+    "digestset",
+    "reference",
+  ]
+  pruneopts = "UT"
+  revision = "2461543d988979529609e8cb6fca9ca190dc48da"
+  version = "v2.7.1"
 
 [[projects]]
   digest = "1:2b5f431fa18891a2ac0e02353c83fb3bf458fced6ccecd664b429054e0c4ce3b"
@@ -54,12 +73,34 @@
   version = "v1.3.3"
 
 [[projects]]
+  digest = "1:0aeda02073125667ac6c9df50c7921cb22c08a4accdc54589c697a7e76be65c2"
+  name = "github.com/google/go-cmp"
+  packages = [
+    "cmp",
+    "cmp/internal/diff",
+    "cmp/internal/flags",
+    "cmp/internal/function",
+    "cmp/internal/value",
+  ]
+  pruneopts = "UT"
+  revision = "5a6f75716e1203a923a78c9efb94089d857df0f6"
+  version = "v0.4.0"
+
+[[projects]]
   digest = "1:a840b166971a2e76fcc4fbafaa181ea109b92d461e7f9b608a49b70be2765bac"
   name = "github.com/google/gofuzz"
   packages = ["."]
   pruneopts = "UT"
   revision = "db92cf7ae75e4a7a28abc005addab2b394362888"
   version = "v1.1.0"
+
+[[projects]]
+  digest = "1:582b704bebaa06b48c29b0cec224a6058a09c86883aaddabde889cd1a5f73e1b"
+  name = "github.com/google/uuid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "0cd6bf5da1e1c83f8b45653022c74f71af0538a4"
+  version = "v1.1.1"
 
 [[projects]]
   digest = "1:e35285db21b7d730a52b891a959783e567ca516ea64f2748070f1f917fbccd82"
@@ -82,6 +123,14 @@
   version = "v1.1.9"
 
 [[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = "UT"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
@@ -98,12 +147,79 @@
   version = "1.0.1"
 
 [[projects]]
+  digest = "1:ee4d4af67d93cc7644157882329023ce9a7bcfce956a079069a9405521c7cc8d"
+  name = "github.com/opencontainers/go-digest"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
+  version = "v1.0.0-rc1"
+
+[[projects]]
+  digest = "1:e5d0bd87abc2781d14e274807a470acd180f0499f8bf5bb18606e9ec22ad9de9"
+  name = "github.com/pborman/uuid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "adf5a7427709b9deb95d29d3fa8a2bf9cfd388f1"
+  version = "v1.2"
+
+[[projects]]
   digest = "1:9e1d37b58d17113ec3cb5608ac0382313c5b59470b94ed97d0976e69c7022314"
   name = "github.com/pkg/errors"
   packages = ["."]
   pruneopts = "UT"
   revision = "614d223910a179a466c1767a985424175c39b465"
   version = "v0.9.1"
+
+[[projects]]
+  digest = "1:7097829edd12fd7211fca0d29496b44f94ef9e6d72f88fb64f3d7b06315818ad"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/internal",
+  ]
+  pruneopts = "UT"
+  revision = "170205fb58decfd011f1550d4cfb737230d7ae4f"
+  version = "v1.1.0"
+
+[[projects]]
+  digest = "1:0db23933b8052702d980a3f029149b3f175f7c0eea0cff85b175017d0f2722c0"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = "UT"
+  revision = "7bc5445566f0fe75b15de23e6b93886e982d7bf9"
+  version = "v0.2.0"
+
+[[projects]]
+  digest = "1:c1139d84a6fab0d2ebfda1ab3fe5f822162be845045db230aa1c672927d320c8"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "UT"
+  revision = "d978bcb1309602d68bb4ba69cf3f8ed900e07308"
+  version = "v0.9.1"
+
+[[projects]]
+  digest = "1:5dc7e10a8b70e01a67e232210cb78758630895a0a7fd69d4b909f31d188250e6"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/fs",
+    "internal/util",
+  ]
+  pruneopts = "UT"
+  revision = "46159f73e74d1cb8dc223deef9b2d049286f46b1"
+  version = "v0.0.11"
+
+[[projects]]
+  digest = "1:524b71991fc7d9246cc7dc2d9e0886ccb97648091c63e30eef619e6862c955dd"
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2e9d26c8c37aae03e3f9d4e90b7116f5accb7cab"
+  version = "v1.0.5"
 
 [[projects]]
   branch = "master"
@@ -261,14 +377,28 @@
   version = "kubernetes-1.15.4"
 
 [[projects]]
-  digest = "1:e0dad81c7448a8c8f39280f5dacd2921b72953e164549738d792345c15d250b9"
+  digest = "1:b8f94dc6fc6922d3ed2244a6798f4f5d4cf6380608adacb1d5eda9878d1945f8"
+  name = "k8s.io/apiextensions-apiserver"
+  packages = ["pkg/features"]
+  pruneopts = "UT"
+  revision = "3de75813f60447b64b34060fdaabd9bc23627eba"
+  version = "kubernetes-1.15.4"
+
+[[projects]]
+  digest = "1:fb7f2ef088a29a7839d4fee41298c07e05c1f00f14a50a636e08889ac774d260"
   name = "k8s.io/apimachinery"
   packages = [
+    "pkg/api/equality",
     "pkg/api/errors",
     "pkg/api/meta",
     "pkg/api/resource",
+    "pkg/api/validation",
+    "pkg/api/validation/path",
+    "pkg/apis/meta/internalversion",
     "pkg/apis/meta/v1",
     "pkg/apis/meta/v1/unstructured",
+    "pkg/apis/meta/v1/validation",
+    "pkg/apis/meta/v1beta1",
     "pkg/conversion",
     "pkg/conversion/queryparams",
     "pkg/fields",
@@ -284,6 +414,7 @@
     "pkg/selection",
     "pkg/types",
     "pkg/util/clock",
+    "pkg/util/diff",
     "pkg/util/errors",
     "pkg/util/framer",
     "pkg/util/intstr",
@@ -292,9 +423,11 @@
     "pkg/util/mergepatch",
     "pkg/util/naming",
     "pkg/util/net",
+    "pkg/util/rand",
     "pkg/util/runtime",
     "pkg/util/sets",
     "pkg/util/strategicpatch",
+    "pkg/util/uuid",
     "pkg/util/validation",
     "pkg/util/validation/field",
     "pkg/util/yaml",
@@ -305,6 +438,30 @@
   ]
   pruneopts = "UT"
   revision = "f2f3a405f61d6c2cdc0d00687c1b5d90de91e9f0"
+  version = "kubernetes-1.15.4"
+
+[[projects]]
+  digest = "1:2c4972db00ce48a947be0894bd173d6f96d864fa8befd50e023208f7b3bb2940"
+  name = "k8s.io/apiserver"
+  packages = [
+    "pkg/admission",
+    "pkg/apis/apiserver",
+    "pkg/apis/apiserver/v1alpha1",
+    "pkg/apis/audit",
+    "pkg/apis/audit/v1",
+    "pkg/apis/audit/v1alpha1",
+    "pkg/apis/audit/v1beta1",
+    "pkg/audit",
+    "pkg/authentication/user",
+    "pkg/authorization/authorizer",
+    "pkg/endpoints/request",
+    "pkg/features",
+    "pkg/registry/rest",
+    "pkg/storage/names",
+    "pkg/util/feature",
+  ]
+  pruneopts = "UT"
+  revision = "1e17798da8c195eb4463c69e3e459967670e24e6"
   version = "kubernetes-1.15.4"
 
 [[projects]]
@@ -336,6 +493,14 @@
   version = "v12.0.0"
 
 [[projects]]
+  digest = "1:661387e3ba412767f773c327c3752e05f13b280677661d77de30345e598ddc01"
+  name = "k8s.io/component-base"
+  packages = ["featuregate"]
+  pruneopts = "UT"
+  revision = "ed2f0867c77835b4733c8ed6f9750cd34ee9c4a7"
+  version = "kubernetes-1.15.4"
+
+[[projects]]
   digest = "1:93e82f25d75aba18436ad1ac042cb49493f096011f2541075721ed6f9e05c044"
   name = "k8s.io/klog"
   packages = ["."]
@@ -352,10 +517,45 @@
   revision = "addea2498afe5a6d58f8bdcd9ae51363d12f12ef"
 
 [[projects]]
+  digest = "1:c8a3fc0adb4fffb0062b881c5d514dfd56fcd331ef2ceff0533d2b013e164cf8"
+  name = "k8s.io/kubernetes"
+  packages = [
+    "pkg/api/legacyscheme",
+    "pkg/api/pod",
+    "pkg/api/service",
+    "pkg/apis/apps",
+    "pkg/apis/apps/validation",
+    "pkg/apis/autoscaling",
+    "pkg/apis/core",
+    "pkg/apis/core/helper",
+    "pkg/apis/core/pods",
+    "pkg/apis/core/v1",
+    "pkg/apis/core/v1/helper",
+    "pkg/apis/core/validation",
+    "pkg/apis/scheduling",
+    "pkg/capabilities",
+    "pkg/features",
+    "pkg/fieldpath",
+    "pkg/kubelet/types",
+    "pkg/master/ports",
+    "pkg/registry/apps/deployment",
+    "pkg/security/apparmor",
+    "pkg/util/parsers",
+  ]
+  pruneopts = "UT"
+  revision = "67d2fcf276fcd9cf743ad4be9a9ef5828adc082f"
+  version = "v1.15.4"
+
+[[projects]]
   branch = "master"
-  digest = "1:8a5e4720aca8a94c876d960a2b86afcaf98e8ded4b5bd7fe42d920806b292c57"
+  digest = "1:125944bb9ab6497dacaebd183dd155601c899e2be4e4b03de5c093ccbfdcbd97"
   name = "k8s.io/utils"
-  packages = ["integer"]
+  packages = [
+    "integer",
+    "net",
+    "path",
+    "pointer",
+  ]
   pruneopts = "UT"
   revision = "861946025e3491219eaccb1bf693e23df70c2fa8"
 
@@ -387,16 +587,21 @@
     "github.com/evanphx/json-patch",
     "github.com/go-logr/logr",
     "github.com/go-logr/logr/testing",
+    "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
+    "k8s.io/apimachinery/pkg/conversion",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/util/jsonmergepatch",
     "k8s.io/apimachinery/pkg/util/strategicpatch",
     "k8s.io/apimachinery/pkg/util/yaml",
     "k8s.io/client-go/kubernetes/scheme",
+    "k8s.io/kubernetes/pkg/apis/apps",
+    "k8s.io/kubernetes/pkg/apis/core/v1",
+    "k8s.io/kubernetes/pkg/registry/apps/deployment",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/fake",
     "sigs.k8s.io/yaml",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,6 +24,10 @@
 #   go-tests = true
 #   unused-packages = true
 
+[[override]]
+  name = "k8s.io/kubernetes"
+  version = "=v1.15.4"
+
 [[constraint]]
   name = "k8s.io/apimachinery"
   version = "kubernetes-1.15.4"

--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ func ApplyWith(options []ApplyOption) *ApplyOptions {
 	result := &ApplyOptions{
 		ForCreate: &metav1.CreateOptions{},
 		ForUpdate: &metav1.UpdateOptions{},
+		Overwrite: true,
 	}
 	for _, f := range options {
 		f.ApplyWith(result)

--- a/overlay/overlay.go
+++ b/overlay/overlay.go
@@ -1,0 +1,36 @@
+package overlay
+
+// Overlays the values of src onto tgt
+func Copy(src, tgt map[string]interface{}) {
+	for k, v := range src {
+		switch y := tgt[k].(type) {
+		case map[string]interface{}:
+			if x, ok := v.(map[string]interface{}); ok {
+				Copy(x, y)
+			} else {
+				tgt[k] = v
+			}
+		case []interface{}:
+			if x, ok := v.([]interface{}); ok {
+				if len(y) < len(x) {
+					tgt[k] = v
+					continue
+				}
+				for i := range x {
+					xi, xok := x[i].(map[string]interface{})
+					yi, yok := y[i].(map[string]interface{})
+					if xok && yok {
+						Copy(xi, yi)
+					} else {
+						y[i] = x[i]
+					}
+				}
+				tgt[k] = y[:len(x)]
+			} else {
+				tgt[k] = v
+			}
+		default:
+			tgt[k] = v
+		}
+	}
+}

--- a/overlay/overlay_test.go
+++ b/overlay/overlay_test.go
@@ -1,0 +1,126 @@
+package overlay_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/manifestival/manifestival/overlay"
+	"sigs.k8s.io/yaml"
+)
+
+type overlayTestCase struct {
+	Name   string
+	Source map[string]interface{}
+	Target map[string]interface{}
+	Expect map[string]interface{}
+}
+
+var testdata = []byte(`
+- name: identical maps
+  source:
+    x: foo
+  target:
+    x: foo
+  expect:
+    x: foo
+- name: changed key value
+  source:
+    x:
+      name: larry
+  target:
+    x:
+      name: curly
+  expect:
+    x:
+      name: larry
+- name: extra map key
+  source:
+    x:
+      name: moe
+  target:
+    x:
+      y: 2
+  expect:
+    x:
+      y: 2
+      name: moe
+- name: retain extra key in target list
+  source:
+    x:
+    - name: larry
+      age: 23
+  target:
+    x:
+    - name: curly
+      age: 42
+      clusterIP: 1.2.3.4
+  expect:
+    x:
+    - name: larry
+      age: 23
+      clusterIP: 1.2.3.4
+- name: too many in target
+  source:
+    x:
+    - name: larry
+      age: 23
+  target:
+    x:
+    - name: curly
+      age: 42
+    - name: larry
+      age: 66
+  expect:
+    x:
+    - name: larry
+      age: 23
+- name: too few in target
+  source:
+    x:
+    - name: curly
+      age: 42
+    - name: larry
+      age: 66
+  target:
+    x:
+    - t: texas
+      y: ynot
+  expect:
+    x:
+    - name: curly
+      age: 42
+    - name: larry
+      age: 66
+- name: different types
+  source:
+    x:
+      name: curly
+      age: 42
+  target:
+    x:
+    - name: curly
+      age: 42
+    - name: larry
+      age: 66
+  expect:
+    x:
+      name: curly
+      age: 42
+`)
+
+func TestOverlay(t *testing.T) {
+	tests := []overlayTestCase{}
+	err := yaml.Unmarshal(testdata, &tests)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			overlay.Copy(test.Source, test.Target)
+			if !reflect.DeepEqual(test.Target, test.Expect) {
+				t.Errorf("\n     got %s\nexpected %s", test.Target, test.Expect)
+			}
+		})
+	}
+}

--- a/testdata/kourier/deployment-edited.json
+++ b/testdata/kourier/deployment-edited.json
@@ -1,0 +1,143 @@
+{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "annotations": {
+      "deployment.kubernetes.io/revision": "8",
+      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"apps/v1\",\"kind\":\"Deployment\",\"metadata\":{\"annotations\":{\"serving.knative.openshift.io/ownerName\":\"knative-serving\",\"serving.knative.openshift.io/ownerNamespace\":\"knative-serving\"},\"name\":\"3scale-kourier-gateway\",\"namespace\":\"knative-serving-ingress\"},\"spec\":{\"selector\":{\"matchLabels\":{\"app\":\"3scale-kourier-gateway\"}},\"template\":{\"metadata\":{\"labels\":{\"app\":\"3scale-kourier-gateway\"}},\"spec\":{\"containers\":[{\"args\":[\"-c\",\"/tmp/config/envoy-bootstrap.yaml\"],\"command\":[\"/usr/local/bin/envoy\"],\"image\":\"docker.io/maistra/proxyv2-ubi8:1.0.8\",\"imagePullPolicy\":\"Always\",\"name\":\"kourier-gateway\",\"ports\":[{\"containerPort\":8080,\"name\":\"http2\",\"protocol\":\"TCP\"},{\"containerPort\":8443,\"name\":\"https\",\"protocol\":\"TCP\"}],\"readinessProbe\":{\"httpGet\":{\"httpHeaders\":[{\"name\":\"Host\",\"value\":\"internalkourier\"}],\"path\":\"/__internalkouriersnapshot\",\"port\":8081,\"scheme\":\"HTTP\"},\"initialDelaySeconds\":5,\"periodSeconds\":2},\"volumeMounts\":[{\"mountPath\":\"/tmp/config\",\"name\":\"config-volume\"}]}],\"restartPolicy\":\"Always\",\"volumes\":[{\"configMap\":{\"name\":\"kourier-bootstrap\"},\"name\":\"config-volume\"}]}}}}\n",
+      "manifestival": "new",
+      "serving.knative.openshift.io/ownerName": "knative-serving",
+      "serving.knative.openshift.io/ownerNamespace": "knative-serving"
+    },
+    "creationTimestamp": "2020-03-24T18:26:04Z",
+    "generation": 8,
+    "labels": {
+      "app": "3scale-kourier-gateway"
+    },
+    "name": "3scale-kourier-gateway",
+    "namespace": "knative-serving-ingress",
+    "resourceVersion": "52168",
+    "selfLink": "/apis/apps/v1/namespaces/knative-serving-ingress/deployments/3scale-kourier-gateway",
+    "uid": "f0e5e343-a751-40b8-8239-1dd96234c695"
+  },
+  "spec": {
+    "progressDeadlineSeconds": 600,
+    "replicas": 1,
+    "revisionHistoryLimit": 10,
+    "selector": {
+      "matchLabels": {
+        "app": "3scale-kourier-gateway"
+      }
+    },
+    "strategy": {
+      "rollingUpdate": {
+        "maxSurge": "25%",
+        "maxUnavailable": "25%"
+      },
+      "type": "RollingUpdate"
+    },
+    "template": {
+      "metadata": {
+        "creationTimestamp": null,
+        "labels": {
+          "app": "3scale-kourier-gateway"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "args": [
+              "-c",
+              "/tmp/config/envoy-bootstrap.yaml"
+            ],
+            "command": [
+              "/usr/local/bin/envoy"
+            ],
+            "image": "docker.io/maistra/proxyv2-ubi8:1.0.8",
+            "imagePullPolicy": "Always",
+            "name": "kourier-gateway",
+            "ports": [
+              {
+                "containerPort": 8081,
+                "name": "http2",
+                "protocol": "TCP"
+              },
+              {
+                "containerPort": 8443,
+                "name": "https",
+                "protocol": "TCP"
+              }
+            ],
+            "readinessProbe": {
+              "failureThreshold": 3,
+              "httpGet": {
+                "httpHeaders": [
+                  {
+                    "name": "Host",
+                    "value": "internalkourier"
+                  }
+                ],
+                "path": "/__internalkouriersnapshot",
+                "port": 8081,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 5,
+              "periodSeconds": 2,
+              "successThreshold": 1,
+              "timeoutSeconds": 1
+            },
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File",
+            "volumeMounts": [
+              {
+                "mountPath": "/tmp/config",
+                "name": "config-volume"
+              }
+            ]
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "terminationGracePeriodSeconds": 30,
+        "volumes": [
+          {
+            "configMap": {
+              "defaultMode": 420,
+              "name": "kourier-bootstrap"
+            },
+            "name": "config-volume"
+          }
+        ]
+      }
+    }
+  },
+  "status": {
+    "availableReplicas": 1,
+    "conditions": [
+      {
+        "lastTransitionTime": "2020-03-24T18:26:37Z",
+        "lastUpdateTime": "2020-03-24T18:26:37Z",
+        "message": "Deployment has minimum availability.",
+        "reason": "MinimumReplicasAvailable",
+        "status": "True",
+        "type": "Available"
+      },
+      {
+        "lastTransitionTime": "2020-03-24T18:26:04Z",
+        "lastUpdateTime": "2020-03-24T19:21:42Z",
+        "message": "ReplicaSet \"3scale-kourier-gateway-58bd7664b5\" is progressing.",
+        "reason": "ReplicaSetUpdated",
+        "status": "True",
+        "type": "Progressing"
+      }
+    ],
+    "observedGeneration": 8,
+    "readyReplicas": 1,
+    "replicas": 2,
+    "unavailableReplicas": 1,
+    "updatedReplicas": 1
+  }
+}

--- a/testdata/kourier/deployment-spec.json
+++ b/testdata/kourier/deployment-spec.json
@@ -1,0 +1,84 @@
+{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "annotations": {
+      "serving.knative.openshift.io/ownerName": "knative-serving",
+      "serving.knative.openshift.io/ownerNamespace": "knative-serving"
+    },
+    "name": "3scale-kourier-gateway",
+    "namespace": "knative-serving-ingress"
+  },
+  "spec": {
+    "selector": {
+      "matchLabels": {
+        "app": "3scale-kourier-gateway"
+      }
+    },
+    "template": {
+      "metadata": {
+        "labels": {
+          "app": "3scale-kourier-gateway"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "args": [
+              "-c",
+              "/tmp/config/envoy-bootstrap.yaml"
+            ],
+            "command": [
+              "/usr/local/bin/envoy"
+            ],
+            "image": "docker.io/maistra/proxyv2-ubi8:1.0.8",
+            "imagePullPolicy": "Always",
+            "name": "kourier-gateway",
+            "ports": [
+              {
+                "containerPort": 8080,
+                "name": "http2",
+                "protocol": "TCP"
+              },
+              {
+                "containerPort": 8443,
+                "name": "https",
+                "protocol": "TCP"
+              }
+            ],
+            "readinessProbe": {
+              "httpGet": {
+                "httpHeaders": [
+                  {
+                    "name": "Host",
+                    "value": "internalkourier"
+                  }
+                ],
+                "path": "/__internalkouriersnapshot",
+                "port": 8081,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 5,
+              "periodSeconds": 2
+            },
+            "volumeMounts": [
+              {
+                "mountPath": "/tmp/config",
+                "name": "config-volume"
+              }
+            ]
+          }
+        ],
+        "restartPolicy": "Always",
+        "volumes": [
+          {
+            "configMap": {
+              "name": "kourier-bootstrap"
+            },
+            "name": "config-volume"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #37 

This involves overlaying the manifest fields onto the current
resource, which might contain server-provided, immutable fields absent
from the manifest, e.g. a service's clusterIP or a creationTimestamp.

We take a conservative approach to overlaying objects with entirely
different structures, as might be the case when updating a new
release. This may still error, but there's not a lot we can do other
than delete/create. But I'd prefer the user to make that call.