### PR TITLE
Enalbe "recreate" for "apply"

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,6 +1,8 @@
 package manifestival
 
 import (
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -48,6 +50,8 @@ type ApplyOptions struct {
 	ForCreate *metav1.CreateOptions
 	ForUpdate *metav1.UpdateOptions
 	Overwrite bool
+	Replace   bool
+	Timeout   time.Duration
 }
 type DeleteOptions struct {
 	ForDelete      *metav1.DeleteOptions
@@ -75,6 +79,10 @@ type IgnoreNotFound bool
 // Resolve conflicts by using values from the manifest values
 type Overwrite bool
 
+type Replace bool
+
+type Timeout time.Duration
+
 type dryRunAll struct{} // for both apply and delete
 
 func (dryRunAll) ApplyWith(opts *ApplyOptions) {
@@ -84,6 +92,15 @@ func (dryRunAll) ApplyWith(opts *ApplyOptions) {
 func (i Overwrite) ApplyWith(opts *ApplyOptions) {
 	opts.Overwrite = bool(i)
 }
+
+func (r Replace) ApplyWith(opts *ApplyOptions) {
+	opts.Replace = bool(r)
+}
+
+func (t Timeout) ApplyWith(opts *ApplyOptions) {
+	opts.Timeout = time.Duration(t)
+}
+
 func (f FieldManager) ApplyWith(opts *ApplyOptions) {
 	// TODO: The FM was introduced in k8s 1.14, but not ready to
 	// abandon pre-1.14 users yet. Uncomment when ready.


### PR DESCRIPTION
Fix issue: #48 
Some fields in certain k8s resource is immutable, like `.spec.selector` of `Deployment`. 
When `apply/update` on it will raise exception and break update process, a `recreate` mechanism could resolve the problem although it will terminate service a little while, depends on user.

`Recreate` could be the last option when `merge` and `overwrite` failed, use could enable it like this:

`r.manifest.Apply(mf.Replace(true), mf.Timeout(120))`

Also introduce `timeout` as waiting duration when `deleting`, default 60s.

    