### PR TITLE
Inject namespace into CRD spec.conversion

### DIFF
--- a/manifestival_test.go
+++ b/manifestival_test.go
@@ -44,7 +44,7 @@ func TestPortUpdates(t *testing.T) {
 		}
 		return nil
 	}
-	manifest, _ := ManifestFrom(Slice([]unstructured.Unstructured{*spec}), UseClient(c), UseLogger(logr.TestLogger{T: t}))
+	manifest, _ := ManifestFrom(Slice([]unstructured.Unstructured{*spec}), UseClient(c))
 	if err := manifest.Apply(Overwrite(false)); err == nil {
 		t.Error("Should have received an invalid error")
 	}

--- a/testdata/crd.yaml
+++ b/testdata/crd.yaml
@@ -1,0 +1,62 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: configurations.serving.knative.dev
+  labels:
+    serving.knative.dev/release: "v0.14.0"
+    knative.dev/crd-install: "true"
+    duck.knative.dev/podspecable: "true"
+spec:
+  group: serving.knative.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      # this is a work around so we don't need to flush out the
+      # schema for each version at this time
+      #
+      # see issue: https://github.com/knative/serving/issues/912
+      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: false
+  - name: v1beta1
+    served: true
+    storage: false
+  - name: v1
+    served: true
+    storage: true
+  names:
+    kind: Configuration
+    plural: configurations
+    singular: configuration
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - config
+    - cfg
+  scope: Namespaced
+  subresources:
+    status: {}
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: webhook
+        namespace: knative-serving
+  additionalPrinterColumns:
+  - name: LatestCreated
+    type: string
+    JSONPath: .status.latestCreatedRevisionName
+  - name: LatestReady
+    type: string
+    JSONPath: .status.latestReadyRevisionName
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"

--- a/transform.go
+++ b/transform.go
@@ -43,7 +43,23 @@ func (m Manifest) Transform(fns ...Transformer) (Manifest, error) {
 // the same namespace.
 func InjectNamespace(ns string) Transformer {
 	namespace := resolveEnv(ns)
+	updateService := func(obj map[string]interface{}, fields ...string) error {
+		srv, found, err := unstructured.NestedFieldNoCopy(obj, fields...)
+		if err != nil {
+			return err
+		}
+		if found {
+			m := srv.(map[string]interface{})
+			if _, ok := m["namespace"]; ok {
+				m["namespace"] = namespace
+			}
+		}
+		return nil
+	}
 	return func(u *unstructured.Unstructured) error {
+		if !isClusterScoped(u.GetKind()) {
+			u.SetNamespace(namespace)
+		}
 		switch strings.ToLower(u.GetKind()) {
 		case "namespace":
 			u.SetName(namespace)
@@ -58,25 +74,14 @@ func InjectNamespace(ns string) Transformer {
 		case "validatingwebhookconfiguration", "mutatingwebhookconfiguration":
 			hooks, _, _ := unstructured.NestedFieldNoCopy(u.Object, "webhooks")
 			for _, hook := range hooks.([]interface{}) {
-				m := hook.(map[string]interface{})
-				if c, ok := m["clientConfig"]; ok {
-					cfg := c.(map[string]interface{})
-					if s, ok := cfg["service"]; ok {
-						srv := s.(map[string]interface{})
-						srv["namespace"] = namespace
-					}
+				if err := updateService(hook.(map[string]interface{}), "clientConfig", "service"); err != nil {
+					return err
 				}
 			}
 		case "apiservice":
-			spec, _, _ := unstructured.NestedFieldNoCopy(u.Object, "spec")
-			m := spec.(map[string]interface{})
-			if c, ok := m["service"]; ok {
-				srv := c.(map[string]interface{})
-				srv["namespace"] = namespace
-			}
-		}
-		if !isClusterScoped(u.GetKind()) {
-			u.SetNamespace(namespace)
+			return updateService(u.Object, "spec", "service")
+		case "customresourcedefinition":
+			return updateService(u.Object, "spec", "conversion", "webhookClientConfig", "service")
 		}
 		return nil
 	}


### PR DESCRIPTION
Fixes #55

Factored the logic to update the ServiceReference type into its own
function and rearranged things a bit to ensure namespace-scoped
resources, e.g. RoleBinding, are updated correctly.

Also cleaned up a bit of the testing logic, eliminating extraneous log
messages in the output and redundant length checks in tests that will
happily fail with or without them.