### PR TITLE
Default FieldManager to "manifestival"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - New filter `Predicate`, `ByAnnotation`, that does for annotations
   what `ByLabel` did for labels!
   [#52](https://github.com/manifestival/manifestival/pull/52)
+- Defaulting the `FieldManager` for create/updates to "manifestival"
+  to help reconcile changes in `metadata.managedFields`, in
+  anticipation of server-side apply. [#64](https://github.com/manifestival/manifestival/pull/64)
 
 ### Removed
 

--- a/client.go
+++ b/client.go
@@ -5,6 +5,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+const (
+	defaultManager = FieldManager("manifestival")
+)
+
 // Client includes the operations required by the Manifestival interface
 type Client interface {
 	Create(obj *unstructured.Unstructured, options ...ApplyOption) error
@@ -19,6 +23,7 @@ func ApplyWith(options []ApplyOption) *ApplyOptions {
 		ForUpdate: &metav1.UpdateOptions{},
 		Overwrite: true,
 	}
+	defaultManager.ApplyWith(result)
 	for _, f := range options {
 		f.ApplyWith(result)
 	}


### PR DESCRIPTION
Could possibly be used instead of the "new" annotation that determines
whether namespaces can be deleted, but not really useful for k8s older than 1.18