### PR TITLE
Added support for resources with generated names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-### Changed
-
 ### Added
+
+- Support for generated names: if `metadata.generateName` is set and
+  `metadata.name` is *not* set on any resource in a manifest, that resource will
+  always be _created_ when the manifest is _applied_. [#65](https://github.com/manifestival/manifestival/issues/65)
+
+### Changed
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ override in your unit tests. For example,
 ```go
 func verifySomething(t *testing.T, expected *unstructured.Unstructured) {
     client := fake.Client{
-        Stubs{
+        fake.Stubs{
             Create: func(u *unstructured.Unstructured) error {
                 if !reflect.DeepEqual(u, expected) {
     				t.Error("You did it wrong!")

--- a/manifestival.go
+++ b/manifestival.go
@@ -177,6 +177,10 @@ func (m Manifest) delete(spec *unstructured.Unstructured, opts ...DeleteOption) 
 // get collects a full resource body (or `nil`) from a partial
 // resource supplied in `spec`
 func (m Manifest) get(spec *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	if spec.GetName() == "" && spec.GetGenerateName() != "" {
+		// expected to be created; never fetched
+		return nil, nil
+	}
 	result, err := m.Client.Get(spec)
 	if err != nil {
 		result = nil


### PR DESCRIPTION
They'll always be created when the manifest is applied

Fixes #65