### PR TITLE
Added support for CRD apiextensions.k8s.io/v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Support for generated names: if `metadata.generateName` is set and
   `metadata.name` is *not* set on any resource in a manifest, that resource will
   always be _created_ when the manifest is _applied_. [#65](https://github.com/manifestival/manifestival/issues/65)
+- Support for CRD apiextensions.k8s.io/v1: CRD v1/v1beta has a difference 
+  in the specification on the conversion webhook field, which needs to be 
+  compatible in the InjectNamespace function.
 
 ### Changed
 

--- a/testdata/crd.yaml
+++ b/testdata/crd.yaml
@@ -60,3 +60,68 @@ spec:
   - name: Reason
     type: string
     JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: configurations.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+    duck.knative.dev/podspecable: "true"
+spec:
+  group: serving.knative.dev
+  versions:
+    - &version
+      name: v1alpha1
+      served: true
+      storage: false
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          # this is a work around so we don't need to flush out the
+          # schema for each version at this time
+          #
+          # see issue: https://github.com/knative/serving/issues/912
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: LatestCreated
+          type: string
+          jsonPath: .status.latestCreatedRevisionName
+        - name: LatestReady
+          type: string
+          jsonPath: .status.latestReadyRevisionName
+        - name: Ready
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
+    - << : *version
+      name: v1beta1
+    - << : *version
+      name: v1
+      storage: true
+  names:
+    kind: Configuration
+    plural: configurations
+    singular: configuration
+    categories:
+      - all
+      - knative
+      - serving
+    shortNames:
+      - config
+      - cfg
+  scope: Namespaced
+  conversion:
+    strategy: Webhook
+    webhook:
+      conversionReviewVersions: ["v1", "v1beta1"]
+      clientConfig:
+        service:
+          name: webhook
+          namespace: knative-serving

--- a/transform.go
+++ b/transform.go
@@ -81,6 +81,9 @@ func InjectNamespace(ns string) Transformer {
 		case "apiservice":
 			return updateService(u.Object, "spec", "service")
 		case "customresourcedefinition":
+			if u.GroupVersionKind().Version == "v1" {
+				return updateService(u.Object, "spec", "conversion", "webhook", "clientConfig", "service")
+			}
 			return updateService(u.Object, "spec", "conversion", "webhookClientConfig", "service")
 		}
 		return nil


### PR DESCRIPTION
CRD v1/v1beta has a difference in the specification on the conversion webhook. This causes the conversion webhook namespace field in the CRD to not be replaced when some components are deployed through knative operator, which will cause some failures.

This pr will provide support for CRD apiextensions.k8s.io/v1