### PR TITLE
Add go doc badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Manifestival
 
 [![Build Status](https://travis-ci.org/manifestival/manifestival.svg?branch=master)](https://travis-ci.org/manifestival/manifestival)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/manifestival/manifestival)](https://pkg.go.dev/github.com/manifestival/manifestival)
 
 Manifestival is a library for manipulating a set of unstructured
 Kubernetes resources. Essentially, it enables you to toss a "bag of


### PR DESCRIPTION
As go doc for manifestival frequently is referred, this patch adds the link by go doc badge.

The badge is created by https://pkg.go.dev/badge/.