### PR TITLE
Prevent mutation by Filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-### Added
-
 ### Changed
+
+- It is no longer possible to mutate manifest resources with the
+  `Filter` method, since now only deep copies of each resource are
+  passed to each `Predicate`. The only way to change a manifest's
+  resources is via the `Transform` method. [#75](https://github.com/manifestival/manifestival/issues/75)
+
+### Added
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -139,12 +139,10 @@ theRest := manifest.Filter(Not(rbac))
 m := manifest.Filter(ByLabel("foo", "bar"), ByName("controller"), NoCRDs)
 ```
 
-Because the `Predicate` receives the resource by reference, any
-changes you make to it will be reflected in the returned `Manifest`,
-but _not_ in the one being filtered -- manifests are immutable. Since
-errors are not in the `Predicate` interface, you should limit changes
-to those that won't error. For more complex mutations, use `Transform`
-instead.
+The `Predicate` receives a deep copy of each resource, so no
+modifications made to any resource will be reflected in the returned
+`Manifest`, which is immutable. The only way to alter resources in a
+`Manifest` is with its `Transform` method.
 
 
 ### Transform

--- a/filter.go
+++ b/filter.go
@@ -24,8 +24,8 @@ func (m Manifest) Filter(preds ...Predicate) Manifest {
 	result := m
 	result.resources = []unstructured.Unstructured{}
 	pred := All(preds...)
-	for _, spec := range m.Resources() {
-		if !pred(&spec) {
+	for _, spec := range m.resources {
+		if !pred(spec.DeepCopy()) {
 			continue
 		}
 		result.resources = append(result.resources, spec)

--- a/filter_test.go
+++ b/filter_test.go
@@ -3,10 +3,8 @@ package manifestival_test
 import (
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes/scheme"
 
 	. "github.com/manifestival/manifestival"
 )
@@ -146,46 +144,11 @@ func TestFilter(t *testing.T) {
 func TestFilterMutation(t *testing.T) {
 	m, _ := NewManifest("testdata/k-s-v0.12.1.yaml")
 	bobs := m.Filter(func(u *unstructured.Unstructured) bool {
-		// This is an abuse of a Predicate, but allowed for those
-		// times you'd prefer not to deal with the multi-valued result
-		// of Transform
 		u.SetName("bob")
 		return true
 	})
-
-	if 0 != len(m.Filter(ByName("bob")).Resources()) {
+	if 0 != len(m.Filter(ByName("bob")).Resources()) || 0 != len(bobs.Filter(ByName("bob")).Resources()) {
 		t.Error("Even one bob is too many")
-	}
-	if 55 != len(bobs.Filter(ByName("bob")).Resources()) {
-		t.Error("Not every one is bob")
-	}
-}
-
-func TestConvertFilter(t *testing.T) {
-	manifest, _ := NewManifest("testdata/k-s-v0.12.1.yaml")
-	filter := func(u *unstructured.Unstructured) bool {
-		// Another abuse of Predicate, to ensure Convert works
-		if u.GetKind() == "ConfigMap" {
-			cm := &v1.ConfigMap{}
-			scheme.Scheme.Convert(u, cm, nil)
-			cm.Data["foo"] = "bar"
-			scheme.Scheme.Convert(cm, u, nil)
-			return true
-		}
-		return false
-	}
-	actual := manifest.Filter(filter)
-	if 0 == len(actual.Resources()) {
-		t.Error("Not enough ConfigMaps!")
-	}
-	for _, u := range actual.Resources() {
-		cm := &v1.ConfigMap{}
-		if err := scheme.Scheme.Convert(&u, cm, nil); err != nil {
-			t.Error(err)
-		}
-		if cm.Data["foo"] != "bar" {
-			t.Error("Data not there")
-		}
 	}
 }
 

--- a/transform_test.go
+++ b/transform_test.go
@@ -218,7 +218,11 @@ func TestConvertTransform(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	for _, u := range actual.Filter(ByKind("ConfigMap")).Resources() {
+	configmaps := actual.Filter(ByKind("ConfigMap")).Resources()
+	if len(configmaps) == 0 {
+		t.Error("Not enough configmaps")
+	}
+	for _, u := range configmaps {
 		cm := &v1.ConfigMap{}
 		if err := scheme.Scheme.Convert(&u, cm, nil); err != nil {
 			t.Error(err)


### PR DESCRIPTION
Fixes #75

The ability to chain `Apply` calls to the result of `Filter` made it
necessary to return the actual manifest resources instead of deep
copies. So now the Predicates are passed deep copies, making it
impossible to alter resources by filtering.

Only the Transform method can alter resources, and its multi-value
return prevents the chaining of `Apply` calls.