### PR TITLE
don't inject cross-namespace OwnerReferences

### DIFF
--- a/testdata/inject-owner.yaml
+++ b/testdata/inject-owner.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: good
+  namespace: foo
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: different-namespace
+  namespace: bar
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: cluster-resource


### PR DESCRIPTION
Kubernetes v1.20+ does not support cross-namespace OwnerReferences and will garbage collect the child resource due to an OwnerRefInvalidNamespace.

Along with bypassing ownership injection for cluster-scoped resources, InjectOwner() should also bypass injecting ownerships when the resource and the owner are in different namespaces.