### PR TITLE
Make sure the 'manifestival' annotation is kept regardless of manifest state

### DIFF
--- a/manifestival.go
+++ b/manifestival.go
@@ -143,10 +143,18 @@ func (m Manifest) apply(spec *unstructured.Unstructured, opts ...ApplyOption) er
 		if diff == nil {
 			return nil
 		}
+
+		isResourceCreated := current.GetAnnotations()["manifestival"] == resourceCreated
 		m.log.Info("Merging", "diff", diff)
 		if err := diff.Merge(current); err != nil {
 			return err
 		}
+
+		// Make sure the manifestival annotation is carried over.
+		if isResourceCreated {
+			annotate(current, "manifestival", resourceCreated)
+		}
+
 		return m.update(current, spec, opts...)
 	}
 }

--- a/manifestival_test.go
+++ b/manifestival_test.go
@@ -150,6 +150,37 @@ conditions:
 	}
 }
 
+func TestApplyKeepManifestivalAnnotation(t *testing.T) {
+	current := []byte(`
+apiVersion: v1
+kind: ComponentStatus
+metadata:
+  name: test
+`)
+	resource := &unstructured.Unstructured{}
+	resource.SetAPIVersion("v1")
+	resource.SetKind("ComponentStatus")
+	resource.SetName("test")
+
+	client := fake.New()
+	manifest, _ := ManifestFrom(Reader(bytes.NewReader(current)), UseClient(client))
+
+	manifest.Apply()
+
+	obj, _ := client.Get(resource)
+	if obj.GetAnnotations()["manifestival"] != "new" {
+		t.Errorf("Resource did not contain 'manifestival' annotation after first apply")
+	}
+
+	manifest2, _ := ManifestFrom(Reader(bytes.NewReader(current)), UseClient(client))
+	manifest2.Apply()
+
+	obj, _ = client.Get(resource)
+	if obj.GetAnnotations()["manifestival"] != "new" {
+		t.Errorf("Resource did not contain 'manifestival' annotation after second apply")
+	}
+}
+
 func TestAppend(t *testing.T) {
 	u := &unstructured.Unstructured{}
 	u.SetName("testy")


### PR DESCRIPTION
Currently, the manifestival annotation relies on the annotation being
added to the manifest itself (the object in the manifest gets annotated,
not its deep-copy) and then carried through reusing that same manifest
instance all-the-time.

If a user ever generates a new manifest, even if it is byte-by-byte
identical, the manifestival annotation gets patched away as the new
manifest won't carry that implicit state.

This fixes that by carrying over the manifestival annotation regardless
of state and patch status, if it was set before applying the patch.