### PR TITLE
Allow cluster-scoped owners

### DIFF
--- a/transform.go
+++ b/transform.go
@@ -94,12 +94,7 @@ func InjectNamespace(ns string) Transformer {
 // `owner` to namespace-scoped objects.
 func InjectOwner(owner Owner) Transformer {
 	return func(u *unstructured.Unstructured) error {
-		if !isClusterScoped(u.GetKind()) {
-			// apparently reference counting for cluster-scoped
-			// resources is broken, so trust the GC only for ns-scoped
-			// dependents
-			u.SetOwnerReferences([]v1.OwnerReference{*v1.NewControllerRef(owner, owner.GroupVersionKind())})
-		}
+		u.SetOwnerReferences([]v1.OwnerReference{*v1.NewControllerRef(owner, owner.GroupVersionKind())})
 		return nil
 	}
 }


### PR DESCRIPTION
Remove guard against cluster-scoped resources when injecting owner, since the commented reason for this no longer holds (referenced Kubernetes bug has long since been fixed).

See https://github.com/manifestival/manifestival/issues/90 for discussion.