### PR TITLE
feat! Context-awareness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Updated `github.com/go-logr/logr` to v1.2.4.
 - Updated `sigs.k8s.io/yaml` to v1.3.0.
 - Optionally allow annotation name different than LastAppliedConfigAnnotation [#97](https://github.com/manifestival/manifestival/issues/97)
+- Add context-awareness to clients. **Note: this introduces breaking changes to `Apply`, `Delete`, and all `Client` function calls.** [#101](https://github.com/manifestival/manifestival/issues/101)
 
 ### Added
 

--- a/client.go
+++ b/client.go
@@ -1,6 +1,8 @@
 package manifestival
 
 import (
+	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -11,10 +13,10 @@ const (
 
 // Client includes the operations required by the Manifestival interface
 type Client interface {
-	Create(obj *unstructured.Unstructured, options ...ApplyOption) error
-	Update(obj *unstructured.Unstructured, options ...ApplyOption) error
-	Delete(obj *unstructured.Unstructured, options ...DeleteOption) error
-	Get(obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
+	Create(ctx context.Context, obj *unstructured.Unstructured, options ...ApplyOption) error
+	Update(ctx context.Context, obj *unstructured.Unstructured, options ...ApplyOption) error
+	Delete(ctx context.Context, obj *unstructured.Unstructured, options ...DeleteOption) error
+	Get(ctx context.Context, obj *unstructured.Unstructured) (*unstructured.Unstructured, error)
 }
 
 func ApplyWith(options []ApplyOption) *ApplyOptions {

--- a/dry.go
+++ b/dry.go
@@ -1,6 +1,7 @@
 package manifestival
 
 import (
+	"context"
 	"encoding/json"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
@@ -17,8 +18,8 @@ type MergePatch map[string]interface{}
 // DryRun returns a list of merge patches, either strategic or
 // RFC-7386 for unregistered types, that show the effects of applying
 // the manifest.
-func (m Manifest) DryRun() ([]MergePatch, error) {
-	diffs, err := m.diff()
+func (m Manifest) DryRun(ctx context.Context) ([]MergePatch, error) {
+	diffs, err := m.diff(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -32,10 +33,10 @@ func (m Manifest) DryRun() ([]MergePatch, error) {
 }
 
 // diff loads the resources in the manifest and computes their difference
-func (m Manifest) diff() ([][]byte, error) {
+func (m Manifest) diff(ctx context.Context) ([][]byte, error) {
 	result := make([][]byte, 0, len(m.resources))
 	for _, spec := range m.resources {
-		current, err := m.Client.Get(&spec)
+		current, err := m.Client.Get(ctx, &spec)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				// this resource will be created when applied

--- a/dry_test.go
+++ b/dry_test.go
@@ -2,6 +2,7 @@ package manifestival_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"testing"
@@ -13,10 +14,11 @@ import (
 
 func TestDryRun(t *testing.T) {
 	client := fake.New()
+	ctx := context.Background()
 	current, _ := NewManifest("testdata/dry/current.yaml", UseClient(client))
-	current.Apply()
+	current.Apply(ctx)
 	modified, _ := NewManifest("testdata/dry/modified.yaml", UseClient(client))
-	diffs, err := modified.DryRun()
+	diffs, err := modified.DryRun(ctx)
 	if err != nil {
 		t.Error(err)
 	}
@@ -30,9 +32,10 @@ func TestDryRun(t *testing.T) {
 
 func TestNothingChanged(t *testing.T) {
 	client := fake.New()
+	ctx := context.Background()
 	current, _ := NewManifest("testdata/dry/current.yaml", UseClient(client))
-	current.Apply()
-	diffs, err := current.DryRun()
+	current.Apply(ctx)
+	diffs, err := current.DryRun(ctx)
 	if err != nil {
 		t.Error(err)
 	}
@@ -43,12 +46,13 @@ func TestNothingChanged(t *testing.T) {
 
 func TestKnativeUpgrade(t *testing.T) {
 	client := fake.New()
+	ctx := context.Background()
 	old, _ := NewManifest("testdata/k-s-v0.11.0.yaml", UseClient(client))
-	old.Apply()
+	old.Apply(ctx)
 	new, _ := NewManifest("testdata/k-s-v0.12.1.yaml", UseClient(client))
 	// Transform to omit version label noise
 	unversioned, _ := new.Transform(ignoreReleaseLabel(old))
-	diffs, err := unversioned.DryRun()
+	diffs, err := unversioned.DryRun(ctx)
 	if err != nil {
 		t.Error(err)
 	}
@@ -57,7 +61,7 @@ func TestKnativeUpgrade(t *testing.T) {
 		t.Errorf("Expected %d diffs, got %d", expected, len(diffs))
 	}
 	// Now do unfiltered
-	diffs, err = new.DryRun()
+	diffs, err = new.DryRun(ctx)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Add golang Context as the first argument to all Client interface functions, and all Manifestival functions that require interaction with the k8s apiserver. This is done in accordance with golang conventions for using Context objects in request-response situations.

All currently supported Kubernetes libraries (v1.26+) that depend on k8s.io/client-go must pass a Context object as its first argument. Wiring the parent Context object to client-go or the controller- runtime client helps Manfiestival consumers support features like timeouts, deadlines, and graceful termination.

Fixes #101 

BREAKING CHANGE: This update breaks the current Manfiestival and Client interfaces. The client-go and controller-runtime implementations will need to be similarly updated to accept a Context as the first argument in all methods. Once implemented, end users will need to simultaneously update manfiestival and the respective manifestival client library.