### PR TITLE
feat: Add possibility to sort manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+- Introduced `Sort` to the `Manifestival` interface to reorder resources in a manifest. `ByKindPriority()` helps for Kubernetes dependency-aware sorting [#104](https://github.com/manifestival/manifestival/issues/104)
+
 ### Removed
 
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ See [CHANGELOG.md](CHANGELOG.md)
   * [Sources](#sources)
   * [Append](#append)
   * [Filter](#filter)
+  * [Sort](#sort)
   * [Transform](#transform)
 * [Applying Manifests](#applying-manifests)
   * [Client](#client)
@@ -32,7 +33,7 @@ See [CHANGELOG.md](CHANGELOG.md)
 
 Manifests may be constructed from a variety of sources. Once created,
 they are immutable, but new instances may be created from them using
-their [Append], [Filter] and [Transform] functions.
+their [Append], [Filter], [Sort] and [Transform] functions.
 
 The typical way to create a manifest is by calling `NewManifest`
 
@@ -144,6 +145,25 @@ modifications made to any resource will be reflected in the returned
 `Manifest`, which is immutable. The only way to alter resources in a
 `Manifest` is with its `Transform` method.
 
+
+### Sort
+
+[Sort] enables you to reorder the resources in a manifest. This is particularly useful 
+for ensuring Kubernetes resources are applied in the correct dependency order, 
+such as applying Namespaces before namespaced resources, or ServiceAccounts before 
+Deployments use them.
+
+For Kubernetes dependency-aware sorting, use the provided `ByKindPriority()` function:
+
+```go
+// Sort by Kubernetes deployment dependencies
+// (Namespaces first, then ServiceAccounts, Secrets, ConfigMaps, etc.)
+sorted := manifest.Sort(ByKindPriority())
+```
+
+The `ByKindPriority()` function orders resources according to standard Kubernetes 
+best practices, ensuring that foundational resources like Namespaces and 
+CustomResourceDefinitions are deployed before resources that depend on them.
 
 ### Transform
 

--- a/manifestival.go
+++ b/manifestival.go
@@ -25,6 +25,8 @@ type Manifestival interface {
 	Filter(fns ...Predicate) Manifest
 	// Append the resources from other Manifests to create a new one
 	Append(mfs ...Manifest) Manifest
+	// Sort the resources in a Manifest
+	Sort(lessFunc LessFunc) Manifest
 	// Show how applying the manifest would change the cluster
 	DryRun(ctx context.Context) ([]MergePatch, error)
 }

--- a/sort.go
+++ b/sort.go
@@ -1,0 +1,95 @@
+package manifestival
+
+import (
+	"sort"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// LessFunc is a comparison function that returns true if resource a should be ordered before resource b.
+// It follows the same convention as Go's sort package comparison functions.
+type LessFunc func(a, b unstructured.Unstructured) bool
+
+func (m Manifest) Sort(lessFunc LessFunc) Manifest {
+	result := m
+	// Make a copy of the resources slice to avoid modifying the original
+	result.resources = make([]unstructured.Unstructured, len(m.resources))
+	copy(result.resources, m.resources)
+
+	sort.Slice(result.resources, func(i, j int) bool {
+		return lessFunc(result.resources[i], result.resources[j])
+	})
+
+	return result
+}
+
+func ByKindPriority() LessFunc {
+	return func(a, b unstructured.Unstructured) bool {
+		kindA := a.GetKind()
+		kindB := b.GetKind()
+
+		posA := getKindPosition(kindA)
+		posB := getKindPosition(kindB)
+
+		// If positions are different, sort by position
+		if posA != posB {
+			return posA < posB
+		}
+
+		// If positions are the same (both unknown), sort alphabetically by kind
+		return kindA < kindB
+	}
+}
+
+// kindPriorityOrder defines the order in which Kubernetes resources should be deployed.
+// Resources earlier in the list should be deployed before resources later in the list.
+// Based on: https://github.com/helm/helm/blob/3c5d68d62e00e11a3efdf6c4b9d2d07272ae0c75/pkg/release/util/kind_sorter.go#L31
+var kindPriorityOrder = []string{
+	"PriorityClass",
+	"Namespace",
+	"NetworkPolicy",
+	"ResourceQuota",
+	"LimitRange",
+	"PodSecurityPolicy",
+	"PodDisruptionBudget",
+	"ServiceAccount",
+	"Secret",
+	"SecretList",
+	"ConfigMap",
+	"StorageClass",
+	"PersistentVolume",
+	"PersistentVolumeClaim",
+	"CustomResourceDefinition",
+	"ClusterRole",
+	"ClusterRoleList",
+	"ClusterRoleBinding",
+	"ClusterRoleBindingList",
+	"Role",
+	"RoleList",
+	"RoleBinding",
+	"RoleBindingList",
+	"Service",
+	"DaemonSet",
+	"Pod",
+	"ReplicationController",
+	"ReplicaSet",
+	"Deployment",
+	"HorizontalPodAutoscaler",
+	"StatefulSet",
+	"Job",
+	"CronJob",
+	"IngressClass",
+	"Ingress",
+	"APIService",
+	"MutatingWebhookConfiguration",
+	"ValidatingWebhookConfiguration",
+}
+
+func getKindPosition(kind string) int {
+	for i, k := range kindPriorityOrder {
+		if k == kind {
+			return i
+		}
+	}
+	return len(kindPriorityOrder) // Unknown kinds go last
+}

--- a/sort_test.go
+++ b/sort_test.go
@@ -1,0 +1,188 @@
+package manifestival_test
+
+import (
+	"testing"
+
+	. "github.com/manifestival/manifestival"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestByKind(t *testing.T) {
+	// Create test resources in random order
+	resources := []unstructured.Unstructured{
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "batch/v1",
+				"kind":       "Job",
+				"metadata": map[string]interface{}{
+					"name": "test-job",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "test-deployment",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Namespace",
+				"metadata": map[string]interface{}{
+					"name": "test-namespace",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata": map[string]interface{}{
+					"name": "test-secret",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Service",
+				"metadata": map[string]interface{}{
+					"name": "test-service",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata": map[string]interface{}{
+					"name": "test-configmap",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "apiextensions.k8s.io/v1",
+				"kind":       "CustomResourceDefinition",
+				"metadata": map[string]interface{}{
+					"name": "test-crd",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ServiceAccount",
+				"metadata": map[string]interface{}{
+					"name": "test-serviceaccount",
+				},
+			},
+		},
+	}
+
+	manifest := Slice(resources)
+	m, err := ManifestFrom(manifest)
+	if err != nil {
+		t.Fatalf("Failed to create manifest: %v", err)
+	}
+
+	// Sort by Kubernetes dependency order
+	sorted := m.Sort(ByKindPriority())
+	sortedResources := sorted.Resources()
+
+	if len(sortedResources) != 8 {
+		t.Errorf("Expected 8 resources, got %d", len(sortedResources))
+	}
+
+	// Check that dependencies come before dependents
+	expectedOrder := []string{
+		"Namespace",
+		"ServiceAccount",
+		"Secret",
+		"ConfigMap",
+		"CustomResourceDefinition",
+		"Service",
+		"Deployment",
+		"Job",
+	}
+
+	for i, resource := range sortedResources {
+		if resource.GetKind() != expectedOrder[i] {
+			t.Errorf("Expected kind %s at position %d, got %s", expectedOrder[i], i, resource.GetKind())
+		}
+	}
+}
+
+func TestByKindWithUnknownKinds(t *testing.T) {
+	// Create test resources including unknown kinds
+	resources := []unstructured.Unstructured{
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "custom.io/v1",
+				"kind":       "UnknownKind",
+				"metadata": map[string]interface{}{
+					"name": "test-unknown",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Namespace",
+				"metadata": map[string]interface{}{
+					"name": "test-namespace",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "custom.io/v1",
+				"kind":       "AnotherUnknown",
+				"metadata": map[string]interface{}{
+					"name": "test-another",
+				},
+			},
+		},
+		{
+			Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+				"metadata": map[string]interface{}{
+					"name": "test-deployment",
+				},
+			},
+		},
+	}
+
+	manifest := Slice(resources)
+	m, err := ManifestFrom(manifest)
+	if err != nil {
+		t.Fatalf("Failed to create manifest: %v", err)
+	}
+
+	// Sort by Kubernetes dependency order
+	sorted := m.Sort(ByKindPriority())
+	sortedResources := sorted.Resources()
+
+	if len(sortedResources) != 4 {
+		t.Errorf("Expected 4 resources, got %d", len(sortedResources))
+	}
+
+	// Check that known kinds come first, unknown kinds come last
+	expectedOrder := []string{
+		"Namespace",
+		"Deployment",
+		"AnotherUnknown",
+		"UnknownKind",
+	}
+
+	for i, resource := range sortedResources {
+		if resource.GetKind() != expectedOrder[i] {
+			t.Errorf("Expected kind %s at position %d, got %s", expectedOrder[i], i, resource.GetKind())
+		}
+	}
+}


### PR DESCRIPTION
When manifests are loaded they can be in a order which does not make sense to apply (e.g. deployments before their service account exists, etc.). This leads for example to unnecessary pod restarts.

This PR addresses it and adds a `Sort(lessFn)` method which allows to customize the order of the manifests. It also provides a `ByKindPriority()` function, which can be used as a `lessFn`, which sorts the resources by their "priority" (this "priority list" is taken from [helms kind_sorter](https://github.com/helm/helm/blob/3c5d68d62e00e11a3efdf6c4b9d2d07272ae0c75/pkg/release/util/kind_sorter.go#L31))